### PR TITLE
fix: fix onChange not trigger for React

### DIFF
--- a/packages/miniprogram-element/CHANGELOG.md
+++ b/packages/miniprogram-element/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 更新日志
 
+## 0.5.9
+
+* 修复react下onChange事件不触发
+
 ## 0.5.8
 
 * 支持 button 内置组件的 business-id 属性

--- a/packages/miniprogram-element/src/component/input.js
+++ b/packages/miniprogram-element/src/component/input.js
@@ -114,7 +114,7 @@ module.exports = {
         onInputInput(evt) {
             if (!this.domNode) return
 
-            this.domNode.value = evt.detail.value
+            this.domNode.setAttribute('value', evt.detail.value)
             this.callEvent('input', evt)
         },
 

--- a/packages/miniprogram-render/CHANGELOG.md
+++ b/packages/miniprogram-render/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 更新日志
 
+## 0.6.2
+
+* 修复react下onChange事件不触发
+
 ## 0.6.1
 
 * 支持 node 的 remove 方法

--- a/packages/miniprogram-render/src/event/event-target.js
+++ b/packages/miniprogram-render/src/event/event-target.js
@@ -32,6 +32,7 @@ class EventTarget {
         this.ontouchmove = null
         this.ontouchend = null
         this.ontouchcancel = null
+        this.oninput = null
 
         this.$_miniprogramEvent = null // 记录已触发的小程序事件
         this.$_eventHandlerMap = null


### PR DESCRIPTION
React下onChange触发有两个条件:
1.支持input事件
2.value有变更
对于问题1，在document下补齐oninput事件即可
对于问题2，需要将直接修改input的value改为使用setAttribute方法，目的是为了不触发set函数