### PR TITLE
【preact】修复表单组件无法触发事件，为 input/textarea 添加默认的原生事件

### DIFF
--- a/examples/demo7/build/miniprogram.config.js
+++ b/examples/demo7/build/miniprogram.config.js
@@ -1,0 +1,55 @@
+module.exports = {
+    // 页面 origin，默认是 https://miniprogram.default
+    origin: 'https://test.miniprogram.com',
+    // 入口页面路由，默认是 /
+    entry: '/test/aaa',
+    // 页面路由，用于页面间跳转
+    router: {
+        // 路由可以是多个值，支持动态路由
+        index: [
+            '/test/aaa',
+            '/test/bbb',
+        ],
+        log: [
+            '/test/aaa',
+            '/test/bbb',
+        ]
+    },
+    // 特殊路由跳转
+    redirect: {
+        // 跳转遇到同一个 origin 但是不在 router 里的页面时处理方式，支持的值：webview - 使用 web-view 组件打开；error - 抛出异常；none - 默认值；什么都不做，router 配置项中的 key
+        notFound: 'index',
+        // 跳转到 origin 之外的页面时处理方式，值同 notFound
+        accessDenied: 'index',
+    },
+    // app 配置，同 https://developers.weixin.qq.com/miniprogram/dev/reference/configuration/app.html#window
+    app: {
+        navigationBarTitleText: 'miniprogram-project',
+    },
+    // 全局配置
+    global: {},
+    // 页面配置，可以为单个页面做个性化处理，覆盖全局配置
+    pages: {},
+    // 优化
+    optimization: {
+        domSubTreeLevel: 5, // 将多少层级的 dom 子树作为一个自定义组件渲染，支持 1 - 5，默认值为 5
+
+        // 对象复用，当页面被关闭时会回收对象，但是如果有地方保留有对象引用的话，注意要关闭此项，否则可能出问题
+        elementMultiplexing: true, // element 节点复用
+        textMultiplexing: true, // 文本节点复用
+        commentMultiplexing: true, // 注释节点复用
+        domExtendMultiplexing: true, // 节点相关对象复用，如 style、classList 对象等
+
+        styleValueReduce: 5000, // 如果设置 style 属性时存在某个属性的值超过一定值，则进行删减
+        attrValueReduce: 5000, // 如果设置 dom 属性时存在某个属性的值超过一定值，则进行删减
+    },
+    // 项目配置，会被合并到 project.config.json
+    projectConfig: {
+        appid: '',
+        projectname: 'kbone-demo7',
+    },
+    // 包配置，会被合并到 package.json
+    packageConfig: {
+        author: 'wechat-miniprogram',
+    },
+}

--- a/examples/demo7/build/webpack.config.js
+++ b/examples/demo7/build/webpack.config.js
@@ -1,0 +1,58 @@
+var path = require('path')
+var MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+
+module.exports = {
+  mode: 'production',
+  entry: {
+    index: path.resolve(__dirname, '../src/main.js'),
+    log: path.resolve(__dirname, '../src/log.js'),
+  },
+  output: {
+    path: path.resolve(__dirname, '../dist/web'),
+    publicPath: './',
+    filename: '[name].js'
+  },
+  target: 'web',
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          MiniCssExtractPlugin.loader,
+          'css-loader'
+        ],
+      },
+      {
+        test: /\.[t|j]sx?$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        options: {
+          plugins : [ 
+            ['transform-react-jsx', {pragma: 'h'}]
+          ] 
+        }
+      },
+      {
+        test: /\.(png|jpg|gif|svg)$/,
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]?[hash]'
+        }
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['*', '.js', '.vue', '.json']
+  },
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: '[name].css'
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'index.html',
+      chunks: ['index'],
+      template: path.join(__dirname, '../index.html')
+    }),
+  ],
+}

--- a/examples/demo7/build/webpack.mp.config.js
+++ b/examples/demo7/build/webpack.mp.config.js
@@ -1,0 +1,109 @@
+const path = require('path')
+const webpack = require('webpack')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
+const TerserPlugin = require('terser-webpack-plugin')
+const MpPlugin = require('mp-webpack-plugin2')
+
+const isOptimize = false // 是否压缩业务代码，开发者工具可能无法完美支持业务代码使用到的 es 特性，建议自己做代码压缩
+
+module.exports = {
+    mode: 'production',
+    entry: {
+        index: path.resolve(__dirname, '../src/main.js')
+    },
+    output: {
+        path: path.resolve(__dirname, '../dist/mp/common'), // 放到小程序代码目录中的 common 目录下
+        filename: '[name].js', // 必需字段，不能修改
+        library: 'createApp', // 必需字段，不能修改
+        libraryExport: 'default', // 必需字段，不能修改
+        libraryTarget: 'window', // 必需字段，不能修改
+    },
+    target: 'web', // 必需字段，不能修改
+    optimization: {
+        runtimeChunk: false, // 必需字段，不能修改
+        splitChunks: { // 代码分隔配置，不建议修改
+            chunks: 'all',
+            minSize: 1000,
+            maxSize: 0,
+            minChunks: 1,
+            maxAsyncRequests: 100,
+            maxInitialRequests: 100,
+            automaticNameDelimiter: '~',
+            name: true,
+            cacheGroups: {
+                vendors: {
+                    test: /[\\/]node_modules[\\/]/,
+                    priority: -10
+                },
+                default: {
+                    minChunks: 2,
+                    priority: -20,
+                    reuseExistingChunk: true
+                }
+            }
+        },
+
+        minimizer: isOptimize ? [
+            // 压缩CSS
+            new OptimizeCSSAssetsPlugin({
+                assetNameRegExp: /\.(css|wxss)$/g,
+                cssProcessor: require('cssnano'),
+                cssProcessorPluginOptions: {
+                    preset: ['default', {
+                        discardComments: {
+                            removeAll: true,
+                        },
+                        minifySelectors: false, // 因为 wxss 编译器不支持 .some>:first-child 这样格式的代码，所以暂时禁掉这个
+                    }],
+                },
+                canPrint: false
+            }),
+            // 压缩 js
+            new TerserPlugin({
+                test: /\.js(\?.*)?$/i,
+                parallel: true,
+            })
+        ] : [],
+    },
+    module: {
+        rules: [
+            {
+                test: /\.css$/,
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    'css-loader'
+                ],
+            },
+            {
+                test: /\.[t|j]sx?$/,
+                loader: 'babel-loader',
+                exclude: /node_modules/,
+                options: {
+                    plugins: [
+                        ['transform-react-jsx', {pragma: 'h'}]
+                    ]
+                }
+            },
+            {
+                test: /\.(png|jpg|gif|svg)$/,
+                loader: 'file-loader',
+                options: {
+                    name: '[name].[ext]?[hash]'
+                }
+            }
+        ]
+    },
+    resolve: {
+        extensions: ['*', '.js', '.vue', '.json']
+    },
+    plugins: [
+        new webpack.DefinePlugin({
+            'process.env.isMiniprogram': process.env.isMiniprogram, // 注入环境变量，用于业务代码判断
+        }),
+        new MiniCssExtractPlugin({
+            filename: '[name].wxss',
+        }),
+        new MpPlugin(require('./miniprogram.config'))
+    ],
+}

--- a/examples/demo7/index.html
+++ b/examples/demo7/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no,minimal-ui, viewport-fit=cover" />
+    <meta content="yes"name="apple-mobile-web-app-capable"/>
+    <meta content="black"name="apple-mobile-web-app-status-bar-style"/>
+    <meta name="format-detection"content="telephone=no, email=no" />
+    <title>vue</title>
+    <style type="text/css">
+      #app {
+        font-family: 'Avenir', Helvetica, Arial, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        text-align: center;
+        color: #2c3e50;
+        margin-top: 60px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/demo7/package.json
+++ b/examples/demo7/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "omi-kbone",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [
+    "omi",
+    "kbone",
+    "mp"
+  ],
+  "scripts": {
+    "build": "rimraf build/web && cross-env NODE_ENV=production webpack --config build/webpack.config.js --progress --hide-modules",
+    "mp": "cross-env NODE_ENV=production webpack --config build/webpack.mp.config.js --progress --hide-modules"
+  },
+  "dependencies": {
+    "omis": "latest",
+    "preact": "^10.1.1"
+  },
+  "browserslist": [
+    "> 1%",
+    "last 2 versions",
+    "not ie <= 8"
+  ],
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-env": "^1.6.0",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
+    "babel-preset-stage-3": "^6.24.1",
+    "cross-env": "^5.0.5",
+    "css-loader": "^0.28.7",
+    "extract-text-webpack-plugin": "^3.0.2",
+    "file-loader": "^1.1.4",
+    "html-webpack-plugin": "^4.0.0-beta.5",
+    "mini-css-extract-plugin": "^0.5.0",
+    "optimize-css-assets-webpack-plugin": "^5.0.1",
+    "stylehacks": "^4.0.3",
+    "webpack": "^4.29.6",
+    "webpack-cli": "^3.2.3",
+    "mp-webpack-plugin2": "latest"
+  },
+  "license": "MIT"
+}

--- a/examples/demo7/src/components/App/_index.css
+++ b/examples/demo7/src/components/App/_index.css
@@ -1,0 +1,3 @@
+span{
+  color: red;
+}

--- a/examples/demo7/src/components/App/index.js
+++ b/examples/demo7/src/components/App/index.js
@@ -1,0 +1,21 @@
+import { h, Component } from 'preact'
+import './_index.css'
+
+const App = (props, store) => {
+  return (
+    <div>
+      我是输入框：
+      <input
+        onClick={e => console.log('click', e)}
+        onInput={e => console.log('input', e)}
+        onFocus={e => console.log('focus', e)}
+        onBlur={e => console.log('blur', e)}
+        onChange={e => console.log('change', e)}
+        onConfirm={e => console.log('confirm', e)}
+        onKeyBoardHeightChange={e => console.log('KeyBoardHeightChange', e)}
+      />
+    </div>
+  )
+}
+
+export default App

--- a/examples/demo7/src/main.js
+++ b/examples/demo7/src/main.js
@@ -1,0 +1,13 @@
+import { render, h } from 'preact'
+import App from './components/App'
+
+export default function createApp() {
+  const container = document.createElement('div')
+  container.id = 'app'
+  document.body.appendChild(container)
+
+  render(<App />, container)
+}
+
+"undefined" != typeof wx && wx.getSystemInfoSync || createApp()
+

--- a/packages/miniprogram-render/CHANGELOG.md
+++ b/packages/miniprogram-render/CHANGELOG.md
@@ -71,3 +71,5 @@
 * 支持内置组件 wx- 前缀写法和直接写法（后者需配置 runtime.wxComponent 的值）
 
 ## next version
+
+* 为虚拟的 input / textarea 元素初始化空的原生事件，修复 preact 下表单组件相关的事件不生效的 bug

--- a/packages/miniprogram-render/src/node/element/input.js
+++ b/packages/miniprogram-render/src/node/element/input.js
@@ -21,7 +21,9 @@ class HTMLInputElement extends Element {
             }
         }
 
-        return new HTMLInputElement(options, tree)
+        const element = new HTMLInputElement(options, tree)
+        element.$$initElementEvents()
+        return element
     }
 
     /**
@@ -88,6 +90,19 @@ class HTMLInputElement extends Element {
             // 特殊字段
             mpplaceholderclass: this.mpplaceholderclass,
         }
+    }
+
+    /**
+     * 兼容 preact
+     * 初始化空的原生事件
+     */
+    $$initElementEvents() {
+        this.oninput = null
+        this.onfocus = null
+        this.onblur = null
+        this.onchange = null
+        this.onconfirm = null
+        this.onkeyboardheightchange = null
     }
 
     /**

--- a/packages/miniprogram-render/src/node/element/textarea.js
+++ b/packages/miniprogram-render/src/node/element/textarea.js
@@ -21,7 +21,9 @@ class HTMLTextAreaElement extends Element {
             }
         }
 
-        return new HTMLTextAreaElement(options, tree)
+        const element = new HTMLTextAreaElement(options, tree)
+        element.$$initElementEvents()
+        return element
     }
 
     /**
@@ -88,6 +90,20 @@ class HTMLTextAreaElement extends Element {
             // 特殊字段
             mpplaceholderclass: this.mpplaceholderclass,
         }
+    }
+
+    /**
+     * 兼容 preact
+     * 初始化空的原生事件
+     */
+    $$initElementEvents() {
+        this.oninput = null
+        this.onfocus = null
+        this.onblur = null
+        this.onchange = null
+        this.onconfirm = null
+        this.onkeyboardheightchange = null
+        this.onlinechange = null
     }
 
     /**


### PR DESCRIPTION
### 问题

在提供的默认 preact 例子里，input 的相关事件都是无法生效的。我通过从 kbone 和 preact 的源码里发现，因为 preact 会检查一次当前事件是否为 dom 的原生事件，是的话则改为小写等待触发，否则还是为大写的事件。

https://github.com/preactjs/preact/blob/398eb99fa28e62b19b2791c9ba1ae0b086e4724d/src/diff/props.js#L99

```javascript
// DOM 有 onclick 事件，转换为小写等待触发
onClick => click

// DOM 没有 onconfirm 事件，仍是大写等待触发    
onConfirm => Confirm        
```

然而 kbone 的事件默认都是以小写事件来 trigger 的，所以当我们的 dom 没有该事件时，就会 match 不到。

https://github.com/wechat-miniprogram/kbone/blob/87f9df5522640cd983afb321408acf50cc1e7342/packages/miniprogram-element/src/component/input.js#L138

### 解决

将 miniprogram-render 的 `HTMLInputElement` 添加上微信文档对应的 bindevents，让 preact 认为他们属于原生事件，就可以通过小写成功 match 上了。



